### PR TITLE
feat: Add code review functionality to LlmService

### DIFF
--- a/DevInsightCli.Tests/LlmServiceTests.cs
+++ b/DevInsightCli.Tests/LlmServiceTests.cs
@@ -1,9 +1,13 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Extensions.Configuration;
 using Moq; // Assumes Moq is available as a testing utility
 using DevInsightCli.Services;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks; // Added for Task
+using Microsoft.SemanticKernel; // Added for FunctionResult
 
 namespace DevInsightCli.Tests
 {
@@ -84,5 +88,51 @@ namespace DevInsightCli.Tests
         // which is harder to unit test without more complex mocking of Kernel and its components.
         // Such tests would become integration tests. For now, the constructor tests cover
         // the configuration aspect of Ollama integration.
+
+        [TestMethod]
+        public async Task ReviewCodeAsync_WithValidCodeSnippet_ReturnsReview()
+        {
+            // Arrange
+            var mockConfigurationSectionOllama = new Mock<IConfigurationSection>();
+            mockConfigurationSectionOllama.Setup(s => s["Endpoint"]).Returns("http://localhost:11434");
+            mockConfigurationSectionOllama.Setup(s => s["ModelId"]).Returns("testmodel");
+            mockConfigurationSectionOllama.Setup(s => s["ApiKey"]).Returns("");
+
+            var mockConfiguration = new Mock<IConfiguration>();
+            mockConfiguration.Setup(c => c.GetSection("Ollama"))
+                             .Returns(mockConfigurationSectionOllama.Object);
+
+            // Mock FunctionResult and its underlying value.
+            // FunctionResult's ToString() method returns the string representation of its ValueObject.
+            var expectedReview = "This is a mock code review.";
+            // We need a KernelFunction instance for FunctionResult constructor.
+            // For testing purposes, we can create a simple one if its properties are not deeply accessed.
+            // However, FunctionResult has constructors that can take value and metadata directly,
+            // or a function and a value. Let's try to create a simple FunctionResult.
+            // Looking at Semantic Kernel source, FunctionResult's ToString() returns Value.ToString().
+            // So we need to ensure Value is set.
+            // A simple way to create FunctionResult for testing:
+            var functionResult = new Microsoft.SemanticKernel.FunctionResult(function: null, value: expectedReview);
+
+
+            // Mock LlmService itself to intercept the call to InvokeKernelPromptAsync
+            // Pass the real configuration object to the constructor.
+            // CallBase must be true so the constructor of LlmService runs and initializes _kernel,
+            // otherwise _kernel would be null if InvokeKernelPromptAsync was not virtual and we tried to use _kernel.
+            var mockLlmService = new Mock<LlmService>(mockConfiguration.Object) { CallBase = true };
+
+            mockLlmService.Setup(s => s.InvokeKernelPromptAsync(It.IsAny<string>()))
+                          .ReturnsAsync(functionResult);
+
+            var service = mockLlmService.Object;
+            var codeSnippet = "public void HelloWorld() { Console.WriteLine(\"Hello\"); }";
+
+            // Act
+            var review = await service.ReviewCodeAsync(codeSnippet);
+
+            // Assert
+            Assert.AreEqual(expectedReview, review);
+            mockLlmService.Verify(s => s.InvokeKernelPromptAsync(It.Is<string>(prompt => prompt.Contains(codeSnippet))), Times.Once);
+        }
     }
 }

--- a/DevInsightCli/Services/LlmService.cs
+++ b/DevInsightCli/Services/LlmService.cs
@@ -54,5 +54,32 @@ namespace DevInsightCli.Services
             // Assuming the result is of a type that can be converted to string, e.g., FunctionResult.
             return result.ToString();
         }
+
+        // Protected virtual method for easier mocking in tests
+        protected virtual async Task<Microsoft.SemanticKernel.FunctionResult> InvokeKernelPromptAsync(string prompt)
+        {
+            return await _kernel.InvokePromptAsync(prompt);
+        }
+
+        public async Task<string> ReviewCodeAsync(string codeSnippet)
+        {
+            var prompt = $@"Please act as a code reviewer for the following code snippet. Provide feedback on potential bugs, areas for improvement, adherence to best practices, and code style.
+
+```csharp
+{codeSnippet}
+```
+
+Your review should include:
+1.  **Overall Impression:** A brief summary of the code's quality.
+2.  **Potential Bugs:** Any logical errors or edge cases that might lead to issues.
+3.  **Suggestions for Improvement:** Recommendations for making the code more efficient, readable, or maintainable.
+4.  **Best Practices:** Comments on adherence to common coding principles (e.g., DRY, SOLID).
+5.  **Code Style:** Observations on formatting, naming conventions, etc.
+
+Provide a concise and actionable review.";
+
+            var result = await InvokeKernelPromptAsync(prompt); // Use the virtual method
+            return result.ToString();
+        }
     }
 }


### PR DESCRIPTION
Adds a new method `ReviewCodeAsync` to the `LlmService` to enable code review capabilities using the configured LLM.

Includes:
- `ReviewCodeAsync` method in `LlmService.cs` with a specific prompt for code reviews.
- A protected virtual method `InvokeKernelPromptAsync` to facilitate testing.
- Unit tests for `ReviewCodeAsync` in `LlmServiceTests.cs` with appropriate mocking.